### PR TITLE
Urgent issue with master: wrong task notified after refactor

### DIFF
--- a/Development/Comm-PC/comm.py
+++ b/Development/Comm-PC/comm.py
@@ -181,9 +181,9 @@ if __name__ == "__main__":
         numTransfers = 0
         while(ser.isOpen()):
             for i in range(trajectory.shape[1]):
-                dummy=input('') # Uncomment this if you want to step through the trajectories via user input
-                angles = trajectory[:, i:i+1]
-                #angles = np.zeros((18, 1))
+                #dummy=input('') # Uncomment this if you want to step through the trajectories via user input
+                #angles = trajectory[:, i:i+1]
+                angles = np.zeros((18, 1))
                 sendPacketToMCU(vec2bytes(angles))
                 
                 numTransfers = numTransfers + 1

--- a/Robot/Src/freertos.c
+++ b/Robot/Src/freertos.c
@@ -783,7 +783,7 @@ void StartRxTask(void const * argument)
                     startSeqCount = 0;
                     totalBytesRead = 0;
 
-                    xTaskNotify(defaultTaskHandle, NOTIFIED_FROM_TASK, eSetBits); // Wake control task
+                    xTaskNotify(commandTaskHandle, NOTIFIED_FROM_TASK, eSetBits); // Wake control task
                     xTaskNotify(IMUTaskHandle, NOTIFIED_FROM_TASK, eSetBits); // Wake MPU task
                     continue;
                 }


### PR DESCRIPTION
During the refactor where FreeRTOS was decoupled from Cube, the defaultTask was renamed to the commandTask, since Cube always needs to generate the defaultTask.

The RX thread notified the defaultTask in the old code, but in the new code it needs to notify the commandTask. This is fixed in this pull request.