### PR TITLE
Templates: update not to use double underscores in defines

### DIFF
--- a/Templates/example_c.h
+++ b/Templates/example_c.h
@@ -16,8 +16,8 @@
 
 
 /******************** Define to prevent recursive inclusion ******************/
-#ifndef __EXAMPLE_H__
-#define __EXAMPLE_H__
+#ifndef EXAMPLE_H
+#define EXAMPLE_H
 
 
 
@@ -71,4 +71,4 @@ uint32_t Days_WeeksToDays(uint32_t weeks);
  */
 /* end ModuleNameHeader */
 
-#endif /* __EXAMPLE_H__ */
+#endif /* EXAMPLE_H */

--- a/Templates/template_c.h
+++ b/Templates/template_c.h
@@ -13,8 +13,8 @@
 
 
 
-#ifndef __TEMPLATE_H__
-#define __TEMPLATE_H__
+#ifndef TEMPLATE_H
+#define TEMPLATE_H
 
 
 
@@ -60,4 +60,4 @@
  */
 /* end TODO -- module name defined on line 7 */
 
-#endif /* __TEMPLATE_H__ */
+#endif /* TEMPLATE_H */

--- a/Templates/template_cpp.h
+++ b/Templates/template_cpp.h
@@ -13,8 +13,8 @@
 
 
 
-#ifndef __TEMPLATE_CPP_H__
-#define __TEMPLATE_CPP_H__
+#ifndef TEMPLATE_CPP_H
+#define TEMPLATE_CPP_H
 
 
 
@@ -72,4 +72,4 @@ namespace module_name{
  */
 /* end - Header */
 
-#endif /* __TEMPLATE_CPP_H__ */
+#endif /* TEMPLATE_CPP_H */


### PR DESCRIPTION
Minor thing - proposing that we avoid using __ in any names in our files that are reserved by C++ and C (https://en.cppreference.com/w/cpp/keyword), (https://en.cppreference.com/w/c/keyword)