### PR TITLE
Pull in UdpDriver unit tests

### DIFF
--- a/Common/component/CircularDmaBuffer/CircularDmaBuffer.cpp
+++ b/Common/component/CircularDmaBuffer/CircularDmaBuffer.cpp
@@ -108,6 +108,7 @@ bool CircularDmaBuffer::dataAvail() const {
 
 /**
  * @brief Reads new data in m_buff_p into out_buff, without updating m_buff_tail.
+ * @param out_buff An array where the read data is written to, which must be of sufficient size.
  * @return number of bytes read from m_buff_p into out_buff.
  */
 size_t CircularDmaBuffer::peekBuff(uint8_t *out_buff) const {
@@ -117,6 +118,7 @@ size_t CircularDmaBuffer::peekBuff(uint8_t *out_buff) const {
 
 /**
  * @brief Reads new data in m_buff_p into out_buff, updating the m_buff_tail.
+ * @param out_buff An array where the read data is written to, which must be of sufficient size.
  * @return number of bytes read from m_buff_p into out_buff.
  */
 size_t CircularDmaBuffer::readBuff(uint8_t *out_buff) {

--- a/Common/component/UdpDriver/UdpDriver.cpp
+++ b/Common/component/UdpDriver/UdpDriver.cpp
@@ -15,8 +15,9 @@
 // TODO: test coverage for UdpDriver, set up fixtures to test passing
 //       data between rx/txBuffers and pbufs.
 // TODO: check against template and add doxygen comments
+// TODO: add in correct semaphores
 
-#include <UdpDriver.h>
+#include "UdpDriver.h"
 
 namespace {
 
@@ -75,7 +76,9 @@ bool UdpDriver::setup() {
     bool success = false;
 
     osSemaphoreStaticDef(UdpDriverRecv, &recvSemaphoreControlBlock);
-    recvSemaphore = getOsInterface()->OS_osSemaphoreCreate(osSemaphore(UdpDriverRecv), 1);
+    if ((recvSemaphore = getOsInterface()->OS_osSemaphoreCreate(osSemaphore(UdpDriverRecv), 1)) == NULL) {
+        return false;
+    }
 
     if (!getUdpInterface() || !getOsInterface()) {
         return false;
@@ -93,6 +96,7 @@ bool UdpDriver::setup() {
         getUdpInterface()->udpRecv(const_cast<struct udp_pcb *>(getPcb()), recvCallback, this);
     } else {
         getUdpInterface()->udpRemove(const_cast<struct udp_pcb *>(getPcb()));
+        pcb = nullptr;
     }
 
     return success;

--- a/Common/include/UdpDriver.h
+++ b/Common/include/UdpDriver.h
@@ -32,7 +32,7 @@ public:
               const os::OsInterface *osInterfaceIn);
     ~UdpDriver();
 
-    bool setup();
+    bool setup(udp_recv_fn recvCallback);
     bool receive(uint8_t *rxArrayOut, const size_t numBytes);
     bool transmit(const uint8_t *txArrayIn, const size_t numBytes);
     bool bytesToPacket(const uint8_t *byteArrayIn, const size_t numBytes);

--- a/Common/include/UdpDriver.h
+++ b/Common/include/UdpDriver.h
@@ -32,19 +32,20 @@ public:
               const os::OsInterface *osInterfaceIn);
     ~UdpDriver();
 
+    /* User-facing - typically call directly. */
     bool initialize();
     bool setupReceive(udp_recv_fn recvCallback);
-    void unSetupReceive();
     bool receive(uint8_t *rxArrayOut, const size_t numBytes);
     bool transmit(const uint8_t *txArrayIn, const size_t numBytes);
+
+    /* Utility - public but typically no need to call directly. */
     bool bytesToPacket(const uint8_t *byteArrayIn, const size_t numBytes, struct pbuf *pPbuf) const;
     u16_t packetToBytes(uint8_t *byteArrayOut, const size_t numBytes, struct pbuf *pPbuf) const;
     void signalReceiveCplt();
     void waitReceiveCplt();
 
-    struct pbuf*    getRecvPbuf() const;
-    void            setRecvPbuf(struct pbuf *pPbuf);
-    void            forgetRecvPbuf();
+    /* Accessors - public but typically no need to call directly. */
+    void setRecvPbuf(struct pbuf *pPbuf);
 
     const ip_addr_t                     getIpaddr() const;
     const ip_addr_t                     getIpaddrPc() const;
@@ -53,6 +54,10 @@ public:
     const udp_interface::UdpInterface*  getUdpInterface() const;
     const os::OsInterface*              getOsInterface() const;
     struct udp_pcb*                     getPcb() const;
+    struct pbuf*                        getRecvPbuf() const;
+
+    void forgetPcb();
+    void forgetRecvPbuf();
 
 private:
     /* UdpDriver configuration. */

--- a/Common/include/UdpDriver.h
+++ b/Common/include/UdpDriver.h
@@ -32,7 +32,9 @@ public:
               const os::OsInterface *osInterfaceIn);
     ~UdpDriver();
 
-    bool setup(udp_recv_fn recvCallback);
+    bool initialize();
+    bool setupReceive(udp_recv_fn recvCallback);
+    void unSetupReceive();
     bool receive(uint8_t *rxArrayOut, const size_t numBytes);
     bool transmit(const uint8_t *txArrayIn, const size_t numBytes);
     bool bytesToPacket(const uint8_t *byteArrayIn, const size_t numBytes, struct pbuf *pPbuf);
@@ -41,6 +43,7 @@ public:
     void waitReceiveCplt();
 
     void setRecvPbuf(struct pbuf *pPbuf);
+    void forgetRecvPbuf();
 
     const ip_addr_t                     getIpaddr() const;
     const ip_addr_t                     getIpaddrPc() const;

--- a/Common/include/UdpDriver.h
+++ b/Common/include/UdpDriver.h
@@ -37,13 +37,14 @@ public:
     void unSetupReceive();
     bool receive(uint8_t *rxArrayOut, const size_t numBytes);
     bool transmit(const uint8_t *txArrayIn, const size_t numBytes);
-    bool bytesToPacket(const uint8_t *byteArrayIn, const size_t numBytes, struct pbuf *pPbuf);
-    bool packetToBytes(uint8_t *byteArrayOut, const size_t numBytes, struct pbuf *pPbuf) const;
+    bool bytesToPacket(const uint8_t *byteArrayIn, const size_t numBytes, struct pbuf *pPbuf) const;
+    u16_t packetToBytes(uint8_t *byteArrayOut, const size_t numBytes, struct pbuf *pPbuf) const;
     void signalReceiveCplt();
     void waitReceiveCplt();
 
-    void setRecvPbuf(struct pbuf *pPbuf);
-    void forgetRecvPbuf();
+    struct pbuf*    getRecvPbuf() const;
+    void            setRecvPbuf(struct pbuf *pPbuf);
+    void            forgetRecvPbuf();
 
     const ip_addr_t                     getIpaddr() const;
     const ip_addr_t                     getIpaddrPc() const;
@@ -52,7 +53,6 @@ public:
     const udp_interface::UdpInterface*  getUdpInterface() const;
     const os::OsInterface*              getOsInterface() const;
     struct udp_pcb*                     getPcb() const;
-    struct pbuf*                        getRecvPbuf() const;
 
 private:
     /* UdpDriver configuration. */
@@ -69,6 +69,7 @@ private:
     /* TODO: decide whether NULL or nullptr, since lwIP API will use NULL when setting these. */
     struct udp_pcb *pcb     = nullptr;
     struct pbuf *recvPbuf   = nullptr;
+
     /* Synchronization. */
     mutable osSemaphoreId recvSemaphore; /* TODO: replace with binary semaphore-style task notification. */
     mutable osStaticSemaphoreDef_t recvSemaphoreControlBlock;

--- a/Common/include/UdpDriver.h
+++ b/Common/include/UdpDriver.h
@@ -35,13 +35,12 @@ public:
     bool setup(udp_recv_fn recvCallback);
     bool receive(uint8_t *rxArrayOut, const size_t numBytes);
     bool transmit(const uint8_t *txArrayIn, const size_t numBytes);
-    bool bytesToPacket(const uint8_t *byteArrayIn, const size_t numBytes);
-    bool packetToBytes(uint8_t *byteArrayOut, const size_t numBytes) const;
+    bool bytesToPacket(const uint8_t *byteArrayIn, const size_t numBytes, struct pbuf *pPbuf);
+    bool packetToBytes(uint8_t *byteArrayOut, const size_t numBytes, struct pbuf *pPbuf) const;
     void signalReceiveCplt();
     void waitReceiveCplt();
 
-    void setRxPbuf(struct pbuf *rxPbufIn);
-    void setTxPbuf(struct pbuf *txPbufIn);
+    void setRecvPbuf(struct pbuf *pPbuf);
 
     const ip_addr_t                     getIpaddr() const;
     const ip_addr_t                     getIpaddrPc() const;
@@ -50,8 +49,7 @@ public:
     const udp_interface::UdpInterface*  getUdpInterface() const;
     const os::OsInterface*              getOsInterface() const;
     const struct udp_pcb*               getPcb() const;
-    struct pbuf*                        getRxPbuf() const;
-    struct pbuf*                        getTxPbuf() const;
+    const struct pbuf*                  getPbuf() const;
 
 private:
     /* UdpDriver configuration. */
@@ -67,11 +65,9 @@ private:
     /* Data modified internally by the Raw API. */
     /* TODO: decide whether NULL or nullptr, since lwIP API will use NULL when setting these. */
     const struct udp_pcb *pcb   = nullptr;
-    struct pbuf *rxPbuf         = nullptr;
-    struct pbuf *txPbuf         = nullptr;
+    const struct pbuf *recvPbuf = nullptr;
 
     /* Synchronization. */
-    /* TODO: may need to protect rxPbuf since it is modified by the callback. */
     mutable osSemaphoreId recvSemaphore; // TODO: replace with binary semaphore-style task notification.
     mutable osStaticSemaphoreDef_t recvSemaphoreControlBlock;
 };

--- a/Common/include/UdpDriver.h
+++ b/Common/include/UdpDriver.h
@@ -13,8 +13,8 @@
 #ifndef UDP_DRIVER_H
 #define UDP_DRIVER_H
 
-#include <UdpInterface.h>
-#include <OsInterface.h>
+#include "UdpInterface.h"
+#include "OsInterface.h"
 
 namespace udp_driver {
 

--- a/Common/include/UdpDriver.h
+++ b/Common/include/UdpDriver.h
@@ -48,8 +48,8 @@ public:
     const u16_t                         getPortPc() const;
     const udp_interface::UdpInterface*  getUdpInterface() const;
     const os::OsInterface*              getOsInterface() const;
-    const struct udp_pcb*               getPcb() const;
-    const struct pbuf*                  getPbuf() const;
+    struct udp_pcb*                     getPcb() const;
+    struct pbuf*                        getRecvPbuf() const;
 
 private:
     /* UdpDriver configuration. */
@@ -64,12 +64,13 @@ private:
 
     /* Data modified internally by the Raw API. */
     /* TODO: decide whether NULL or nullptr, since lwIP API will use NULL when setting these. */
-    const struct udp_pcb *pcb   = nullptr;
-    const struct pbuf *recvPbuf = nullptr;
-
+    struct udp_pcb *pcb     = nullptr;
+    struct pbuf *recvPbuf   = nullptr;
     /* Synchronization. */
-    mutable osSemaphoreId recvSemaphore; // TODO: replace with binary semaphore-style task notification.
+    mutable osSemaphoreId recvSemaphore; /* TODO: replace with binary semaphore-style task notification. */
     mutable osStaticSemaphoreDef_t recvSemaphoreControlBlock;
+    mutable osMutexId recvPbufMutex;
+    mutable osStaticMutexDef_t recvPbufMutexControlBlock;
 };
 
 } // end namespace udp_driver

--- a/Common/include/UdpDriver.h
+++ b/Common/include/UdpDriver.h
@@ -38,6 +38,7 @@ public:
     bool bytesToPacket(const uint8_t *byteArrayIn, const size_t numBytes);
     bool packetToBytes(uint8_t *byteArrayOut, const size_t numBytes) const;
     void signalReceiveCplt();
+    void waitReceiveCplt();
 
     void setRxPbuf(struct pbuf *rxPbufIn);
     void setTxPbuf(struct pbuf *txPbufIn);

--- a/Common/include/UdpDriver.h
+++ b/Common/include/UdpDriver.h
@@ -2,7 +2,6 @@
   *****************************************************************************
   * @file    UdpDriver.h
   * @author  Robert Fairley
-  * @brief   Management of simple UDP rx/tx operations.
   *
   * @defgroup Header
   * @ingroup  udp_driver
@@ -10,17 +9,31 @@
   *****************************************************************************
   */
 
+
+
+
 #ifndef UDP_DRIVER_H
 #define UDP_DRIVER_H
 
+
+
+
+/********************************* Includes **********************************/
 #include "UdpInterface.h"
 #include "OsInterface.h"
 
+
+
+/************************** udp_driver **************************/
 namespace udp_driver {
 
+// Constants
+// ----------------------------------------------------------------------------
 constexpr TickType_t SEMAPHORE_WAIT_NUM_MS = 10;
 constexpr TickType_t SEMAPHORE_WAIT_NUM_TICKS = pdMS_TO_TICKS(SEMAPHORE_WAIT_NUM_MS);
 
+// Classes and structs
+// ----------------------------------------------------------------------------
 class UdpDriver {
 public:
     UdpDriver();

--- a/Common/test/CircularDmaBuffer_test.cpp
+++ b/Common/test/CircularDmaBuffer_test.cpp
@@ -56,7 +56,7 @@ protected:
     uint8_t raw_buff_[BUFFER_SIZE_TEST] = { };
     const uint16_t transmission_size_ = BUFFER_SIZE_TEST;
     const size_t buffer_size_ = BUFFER_SIZE_TEST;
-    CircularDmaBuffer * buff_ = nullptr;
+    CircularDmaBuffer* buff_ = nullptr;
 };
 
 // Functions

--- a/Common/test/CircularDmaBuffer_test.cpp
+++ b/Common/test/CircularDmaBuffer_test.cpp
@@ -38,7 +38,6 @@ namespace {
 // Variables
 // ----------------------------------------------------------------------------
 constexpr size_t BUFFER_SIZE_TEST = 100;
-MockUartInterface uart_if;
 
 // Classes & structs
 // ----------------------------------------------------------------------------
@@ -57,11 +56,12 @@ protected:
     const uint16_t transmission_size_ = BUFFER_SIZE_TEST;
     const size_t buffer_size_ = BUFFER_SIZE_TEST;
     CircularDmaBuffer* buff_ = nullptr;
+    MockUartInterface uart_if;
 };
 
 // Functions
 // ----------------------------------------------------------------------------
-TEST(CircularDmaBufferShould, InitializeMembersZeroWithDefaultConstructor) {
+TEST_F(CircularDmaBufferTest, InitializeMembersZeroWithDefaultConstructor) {
     CircularDmaBuffer buff;
 
     EXPECT_EQ(buff.getUartHandle(), nullptr);
@@ -73,7 +73,7 @@ TEST(CircularDmaBufferShould, InitializeMembersZeroWithDefaultConstructor) {
     EXPECT_EQ(buff.getBuffTail(), 0);
 }
 
-TEST(CircularDmaBufferShould, ConstInitializeMembersWithParameterizedConstructor) {
+TEST_F(CircularDmaBufferTest, ConstInitializeMembersWithParameterizedConstructor) {
     constexpr size_t BUFFER_SIZE = 20;
     UART_HandleTypeDef huart;
     uint8_t raw_buff[BUFFER_SIZE] = { };
@@ -92,7 +92,7 @@ TEST(CircularDmaBufferShould, ConstInitializeMembersWithParameterizedConstructor
     EXPECT_EQ(buff.getBuffTail(), 0);
 }
 
-TEST(CircularDmaBufferShould, SucceedSelfCheck) {
+TEST_F(CircularDmaBufferTest, SucceedSelfCheck) {
     constexpr size_t BUFFER_SIZE = 20;
     UART_HandleTypeDef huart;
     uint8_t raw_buff[BUFFER_SIZE] = { };
@@ -107,7 +107,7 @@ TEST(CircularDmaBufferShould, SucceedSelfCheck) {
 
 // TODO: define different test fixtures with variants of m_transmission_size vs. m_buffer_size comparison?
 
-TEST(CircularDmaBufferShould, FailSelfCheck) {
+TEST_F(CircularDmaBufferTest, FailSelfCheck) {
     constexpr size_t BUFFER_SIZE = 8;
     UART_HandleTypeDef huart;
     uint8_t raw_buff[BUFFER_SIZE] = { };
@@ -120,7 +120,7 @@ TEST(CircularDmaBufferShould, FailSelfCheck) {
     EXPECT_FALSE(buff.selfCheck());
 }
 
-TEST(CircularDmaBufferShould, Initiate) {
+TEST_F(CircularDmaBufferTest, Initiate) {
     constexpr size_t BUFFER_SIZE = 20;
     UART_HandleTypeDef huart;
     uint8_t raw_buff[BUFFER_SIZE] = { };
@@ -137,7 +137,7 @@ TEST(CircularDmaBufferShould, Initiate) {
     EXPECT_TRUE(buff.selfCheck());
 }
 
-TEST(CircularDmaBufferShould, AbortReinitiateIfError) {
+TEST_F(CircularDmaBufferTest, AbortReinitiateIfError) {
     constexpr size_t BUFFER_SIZE = 20;
     UART_HandleTypeDef huart;
     uint8_t raw_buff[BUFFER_SIZE] = { };
@@ -154,7 +154,7 @@ TEST(CircularDmaBufferShould, AbortReinitiateIfError) {
     buff.reinitiateIfError();
 }
 
-TEST(CircularDmaBufferShould, NotAbortReinitiateIfNoError) {
+TEST_F(CircularDmaBufferTest, NotAbortReinitiateIfNoError) {
     constexpr size_t BUFFER_SIZE = 20;
     UART_HandleTypeDef huart;
     uint8_t raw_buff[BUFFER_SIZE] = { };

--- a/Common/test/UdpDriver_test.cpp
+++ b/Common/test/UdpDriver_test.cpp
@@ -65,8 +65,6 @@ TEST(UdpDriverShould, DefaultInitializeMembersToZero) {
     EXPECT_EQ(udpDriverUnderTest.getUdpInterface(), nullptr);
     EXPECT_EQ(udpDriverUnderTest.getOsInterface(), nullptr);
     EXPECT_EQ(udpDriverUnderTest.getPcb(), nullptr);
-    EXPECT_EQ(udpDriverUnderTest.getRxPbuf(), nullptr);
-    EXPECT_EQ(udpDriverUnderTest.getTxPbuf(), nullptr);
 }
 
 TEST(UdpDriverShould, InitializeMembersWithParameterizedConstructor) {
@@ -82,6 +80,7 @@ TEST(UdpDriverShould, InitializeMembersWithParameterizedConstructor) {
     EXPECT_EQ((u16_t) 6340, udpDriverUnderTest.getPortPc());
     EXPECT_EQ(&udp_if, udpDriverUnderTest.getUdpInterface());
     EXPECT_EQ(&os_if, udpDriverUnderTest.getOsInterface());
+    EXPECT_EQ(udpDriverUnderTest.getPcb(), nullptr);
 }
 
 
@@ -130,11 +129,9 @@ TEST(UdpDriverShould, FailSetupOnUdpBind) {
     ASSERT_FALSE(udpDriverUnderTest.setup(nullptr));
 }
 
-TEST(UdpDriverRxPbufFilledShould, SucceedReceive) {
+TEST(UdpDriverShould, SucceedReceive) {
     uint8_t rxBuff[10] = {};
 
-    //EXPECT_CALL(udp_if, pbufFree(_)).Times(1).WillOnce(Return((u8_t) 1));
-    EXPECT_CALL(udp_if, pbufCopyPartial(_, _, _, _)).Times(1).WillOnce(Return((u16_t) 1));
     EXPECT_CALL(os_if, OS_osSemaphoreWait(_, _)).Times(1).WillOnce(Return(osOK));
 
     UdpDriver udpDriverUnderTest(ZERO_IP_ADDR_T, ZERO_IP_ADDR_T, (u16_t) 0, (u16_t) 0,

--- a/Common/test/UdpDriver_test.cpp
+++ b/Common/test/UdpDriver_test.cpp
@@ -81,32 +81,28 @@ TEST(UdpDriverShould, InitializeMembersWithParameterizedConstructor) {
 
 
 TEST(UdpDriverShould, SucceedSetup) {
-    mocks::MockUdpInterface mockUdpInterface;
-    mocks::MockOsInterface mockOsInterface;
     struct udp_pcb udpPcb;
 
-    EXPECT_CALL(mockUdpInterface, udpRecv(_, _, _)).Times(1);
-    EXPECT_CALL(mockUdpInterface, udpBind(_, _, _)).Times(1).WillOnce(Return(ERR_OK));
-    EXPECT_CALL(mockUdpInterface, udpNew()).Times(1).WillOnce(Return(&udpPcb));
-    EXPECT_CALL(mockOsInterface, OS_osSemaphoreCreate(_, _)).Times(1).WillOnce(Return((osSemaphoreId) 1));
+    EXPECT_CALL(udp_if, udpRecv(_, _, _)).Times(1);
+    EXPECT_CALL(udp_if, udpBind(_, _, _)).Times(1).WillOnce(Return(ERR_OK));
+    EXPECT_CALL(udp_if, udpNew()).Times(1).WillOnce(Return(&udpPcb));
+    EXPECT_CALL(os_if, OS_osSemaphoreCreate(_, _)).Times(1).WillOnce(Return((osSemaphoreId) 1));
 
     UdpDriver udpDriverUnderTest(ZERO_IP_ADDR_T, ZERO_IP_ADDR_T, (u16_t) 0, (u16_t) 0,
-            &mockUdpInterface, &mockOsInterface);
+            &udp_if, &os_if);
     ASSERT_TRUE(udpDriverUnderTest.setup());
 }
 
-TEST(UdpDriverTests, FailSetupOnOsSemaphoreCreate) {
-    mocks::MockUdpInterface mockUdpInterface;
-    mocks::MockOsInterface mockOsInterface;
+TEST(UdpDriverShould, FailSetupOnOsSemaphoreCreate) {
 
-    EXPECT_CALL(mockOsInterface, OS_osSemaphoreCreate(_, _)).Times(1).WillOnce(Return((osSemaphoreId) 0));
+    EXPECT_CALL(os_if, OS_osSemaphoreCreate(_, _)).Times(1).WillOnce(Return((osSemaphoreId) 0));
 
     UdpDriver udpDriverUnderTest(ZERO_IP_ADDR_T, ZERO_IP_ADDR_T, (u16_t) 0, (u16_t) 0,
-            &mockUdpInterface, &mockOsInterface);
+            &udp_if, &os_if);
     ASSERT_FALSE(udpDriverUnderTest.setup());
 }
 
-TEST(UdpDriverTests, FailSetupOnUdpNew) {
+TEST(UdpDriverShould, FailSetupOnUdpNew) {
     mocks::MockUdpInterface mockUdpInterface;
     mocks::MockOsInterface mockOsInterface;
 
@@ -118,115 +114,15 @@ TEST(UdpDriverTests, FailSetupOnUdpNew) {
     ASSERT_FALSE(udpDriverUnderTest.setup());
 }
 
-TEST(UdpDriverTests, FailSetupOnUdpBind) {
-    mocks::MockUdpInterface mockUdpInterface;
-    mocks::MockOsInterface mockOsInterface;
+TEST(UdpDriverShould, FailSetupOnUdpBind) {
     struct udp_pcb udpPcb;
 
-    EXPECT_CALL(mockUdpInterface, udpRemove(_)).Times(1);
-    EXPECT_CALL(mockUdpInterface, udpBind(_, _, _)).Times(1).WillOnce(Return(ERR_USE));
-    EXPECT_CALL(mockUdpInterface, udpNew()).Times(1).WillOnce(Return(&udpPcb));
-    EXPECT_CALL(mockOsInterface, OS_osSemaphoreCreate(_, _)).Times(1).WillOnce(Return((osSemaphoreId) 1));
+    EXPECT_CALL(udp_if, udpRemove(_)).Times(1);
+    EXPECT_CALL(udp_if, udpBind(_, _, _)).Times(1).WillOnce(Return(ERR_USE));
+    EXPECT_CALL(udp_if, udpNew()).Times(1).WillOnce(Return(&udpPcb));
+    EXPECT_CALL(os_if, OS_osSemaphoreCreate(_, _)).Times(1).WillOnce(Return((osSemaphoreId) 1));
 
     UdpDriver udpDriverUnderTest(ZERO_IP_ADDR_T, ZERO_IP_ADDR_T, (u16_t) 0, (u16_t) 0,
-            &mockUdpInterface, &mockOsInterface);
+            &udp_if, &os_if);
     ASSERT_FALSE(udpDriverUnderTest.setup());
 }
-
-//
-//TEST(UdpDriverTests, FunctionCallsCorrectOrderReceiveSuccess) {
-//    mocks::MockUdpInterface mockUdpInterface;
-//    mocks::MockOsInterface mockOsInterface;
-//    EXPECT_CALL(mockUdpInterface, pbufFree(_)).Times(1).WillOnce(
-//            Return((u8_t) 1));
-//    EXPECT_CALL(mockOsInterface, OS_xSemaphoreTake(_, _)).Times(1).WillOnce(
-//            Return(pdTRUE));
-//
-//    UdpDriver udpDriverUnderTest(ZERO_IP_ADDR_T, ZERO_IP_ADDR_T, ZERO_U16_T, ZERO_U16_T,
-//            &mockUdpInterface, &mockOsInterface);
-//    bool success = udpDriverUnderTest.receive(nullptr);
-//    ASSERT_TRUE(success);
-//}
-//
-//TEST(UdpDriverTests, FunctionCallsCorrectOrderReceiveFailsOnSemaphoreTake) {
-//    mocks::MockUdpInterface mockUdpInterface;
-//    mocks::MockOsInterface mockOsInterface;
-//    EXPECT_CALL(mockOsInterface, OS_xSemaphoreTake(_, _)).Times(1).WillOnce(
-//            Return(pdFALSE));
-//
-//    UdpDriver udpDriverUnderTest(ZERO_IP_ADDR_T, ZERO_IP_ADDR_T, ZERO_U16_T, ZERO_U16_T,
-//            &mockUdpInterface, &mockOsInterface);
-//    bool success = udpDriverUnderTest.receive(nullptr);
-//    ASSERT_FALSE(success);
-//}
-//
-//TEST(UdpDriverTests, FunctionCallsCorrectOrderReceiveFailsOnPbufFreeNoneFreed) {
-//    mocks::MockUdpInterface mockUdpInterface;
-//    mocks::MockOsInterface mockOsInterface;
-//    EXPECT_CALL(mockUdpInterface, pbufFree(_)).Times(1).WillOnce(
-//            Return((u8_t) 0));
-//    EXPECT_CALL(mockOsInterface, OS_xSemaphoreTake(_, _)).Times(1).WillOnce(
-//            Return(pdTRUE));
-//
-//    UdpDriver udpDriverUnderTest(ZERO_IP_ADDR_T, ZERO_IP_ADDR_T, ZERO_U16_T, ZERO_U16_T,
-//            &mockUdpInterface, &mockOsInterface);
-//    bool success = udpDriverUnderTest.receive(nullptr);
-//    ASSERT_FALSE(success);
-//}
-//
-//TEST(UdpDriverTests, FunctionCallsCorrectOrderTransmitSuccess) {
-//    mocks::MockUdpInterface mockUdpInterface;
-//    EXPECT_CALL(mockUdpInterface, pbufFree(_)).Times(1).WillOnce(
-//            Return((u8_t) 1));
-//    EXPECT_CALL(mockUdpInterface, udpDisconnect(_)).Times(1);
-//    EXPECT_CALL(mockUdpInterface, udpSend(_, _)).Times(1).WillOnce(
-//            Return(ERR_OK));
-//    EXPECT_CALL(mockUdpInterface, udpConnect(_, _, _)).Times(1).WillOnce(
-//            Return(ERR_OK));
-//
-//    UdpDriver udpDriverUnderTest(ZERO_IP_ADDR_T, ZERO_IP_ADDR_T, ZERO_U16_T, ZERO_U16_T,
-//            &mockUdpInterface, nullptr);
-//    bool success = udpDriverUnderTest.transmit(nullptr);
-//    ASSERT_TRUE(success);
-//}
-//
-//TEST(UdpDriverTests, FunctionCallsCorrectOrderTransmitFailsOnConnect) {
-//    mocks::MockUdpInterface mockUdpInterface;
-//    EXPECT_CALL(mockUdpInterface, udpConnect(_, _, _)).Times(1).WillOnce(
-//            Return(ERR_VAL)); // use ERR_VAL; anything but ERR_OK works
-//
-//    UdpDriver udpDriverUnderTest(ZERO_IP_ADDR_T, ZERO_IP_ADDR_T, ZERO_U16_T, ZERO_U16_T,
-//            &mockUdpInterface, nullptr);
-//    bool success = udpDriverUnderTest.transmit(nullptr);
-//    ASSERT_FALSE(success);
-//}
-//
-//TEST(UdpDriverTests, FunctionCallsCorrectOrderTransmitFailsOnSend) {
-//    mocks::MockUdpInterface mockUdpInterface;
-//    EXPECT_CALL(mockUdpInterface, udpSend(_, _)).Times(1).WillOnce(
-//            Return(ERR_VAL));
-//    EXPECT_CALL(mockUdpInterface, udpConnect(_, _, _)).Times(1).WillOnce(
-//            Return(ERR_OK));
-//
-//    UdpDriver udpDriverUnderTest(ZERO_IP_ADDR_T, ZERO_IP_ADDR_T, ZERO_U16_T, ZERO_U16_T,
-//            &mockUdpInterface, nullptr);
-//    bool success = udpDriverUnderTest.transmit(nullptr);
-//    ASSERT_FALSE(success);
-//}
-//
-//TEST(UdpDriverTests, FunctionCallsCorrectOrderTransmitFailsOnPbufFreeNoneFreed) {
-//    mocks::MockUdpInterface mockUdpInterface;
-//    EXPECT_CALL(mockUdpInterface, pbufFree(_)).Times(1).WillOnce(
-//            Return((u8_t) 0));
-//    EXPECT_CALL(mockUdpInterface, udpDisconnect(_)).Times(1);
-//    EXPECT_CALL(mockUdpInterface, udpSend(_, _)).Times(1).WillOnce(
-//            Return(ERR_OK));
-//    EXPECT_CALL(mockUdpInterface, udpConnect(_, _, _)).Times(1).WillOnce(
-//            Return(ERR_OK));
-//
-//    UdpDriver udpDriverUnderTest(ZERO_IP_ADDR_T, ZERO_IP_ADDR_T, ZERO_U16_T, ZERO_U16_T,
-//            &mockUdpInterface, nullptr);
-//    bool success = udpDriverUnderTest.transmit(nullptr);
-//    ASSERT_FALSE(success);
-//}
-

--- a/Common/test/UdpDriver_test.cpp
+++ b/Common/test/UdpDriver_test.cpp
@@ -2,9 +2,9 @@
   *****************************************************************************
   * @file    UdpDriver_test.cpp
   * @author  Robert Fairley
-  * @brief   Unit tests for UDP driver.
   *
   * @defgroup udp_driver_test
+  * @ingroup  udp_driver
   * @brief    Unit tests for the UdpDriver class.
   * @{
   *****************************************************************************
@@ -12,12 +12,18 @@
 
 /* TODO: investigate threaded tests. */
 
+
+
+/********************************* Includes **********************************/
 #include <MockOsInterface.h>
 #include <MockUdpInterface.h>
 #include <UdpDriver.h>
 
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
+
+
+
 
 using udp_driver::UdpDriver;
 using mocks::MockUdpInterface;
@@ -30,30 +36,25 @@ using ::testing::AnyNumber;
 
 
 
+/* NOTE: needs to be defined outside of anonymous
+namespace so gtest can use it. */
 bool operator==(const ip_addr_t& lhs, const ip_addr_t& rhs) {
     return lhs.addr == rhs.addr;
 }
 
-namespace {
 
+
+
+/******************************** File-local *********************************/
+namespace {
+// Constants
+// ----------------------------------------------------------------------------
 const ip_addr_t ZERO_IP_ADDR_T = {0x0};
 
-// Classes & structs
-// ----------------------------------------------------------------------------
-class UdpDriverTest : public ::testing::Test {
-protected:
-    void SetUp() {
-        udpDriver_ = new UdpDriver(ZERO_IP_ADDR_T, ZERO_IP_ADDR_T, (u16_t) 0, (u16_t) 0,
-                &udp_if, &os_if);
-
-    }
-
-    UdpDriver* udpDriver_;
-    MockUdpInterface udp_if;
-    MockOsInterface os_if;
-};
-
 }
+
+
+
 
 TEST(UdpDriverShould, DefaultInitializeMembersToZero) {
     UdpDriver udpDriverUnderTest;


### PR DESCRIPTION
A lot of changes to the UdpDriver class interface here, but it should be stable now.
- Removes the internal pbuf member used for tx as this can be managed locally within the `transmit` function. Separates initializing the semaphores from setting up lwIP to receive at a certain callback (`initialize` and `setupReceive` respectively).
- Split some functions into public utility functions which can be tested independently of the `receive` and `transmit` functions. 
- allow udp_recv_fn to be passed in to `setupReceive` so that an arbitrary callback function can be specified (ifthe user rewrites `receive` and doesn't use the implementation given in the class).
- Test coverage for success and failure paths of at least the user-facing functions: `initialize`, `setupReceive`, `receive`, `transmit`. The callback (`recvCallback`) cannot be easily tested in the unit tests, we can iterate later to see if threaded tests can be done with gtest.

`CircularDmaBuffer` has minor changes to move `MockUartInterface uart_if` declarations inside each test so `gtest` keeps track of the mocks independently (#150). Also comments are updated.
