### PR TITLE
PeripheralInstances: fix missing SystemConf.h include

### DIFF
--- a/Common/app/PeripheralInstances.cpp
+++ b/Common/app/PeripheralInstances.cpp
@@ -17,6 +17,7 @@
 #include "HalUartInterface.h"
 #include "GpioInterfaceImpl.h"
 #include "OsInterfaceImpl.h"
+#include "SystemConf.h"
 
 #include "usart.h"
 #include "gpio.h"


### PR DESCRIPTION
Needed as PeripheralInstances.cpp uses symbols `UART_HANDLE_*` which are defined in SystemConf.h. Would not build today otherwise; must have got lucky with the linker before.